### PR TITLE
Add missing Accept header. Improve UserAgent.

### DIFF
--- a/src/Openl10n/Sdk/Api.php
+++ b/src/Openl10n/Sdk/Api.php
@@ -31,7 +31,11 @@ class Api
         $this->client = new Client([
             'base_url' => ['{scheme}://{hostname}:{port}/api/', $options->toArray()],
             'defaults' => [
-                'auth' =>  [$config->getLogin(), $config->getPassword()]
+                'auth' =>  [$config->getLogin(), $config->getPassword()],
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Openl10n '.Client::getDefaultUserAgent()
+                ]
             ]
         ]);
 


### PR DESCRIPTION
Sans ces deux headers, le mod_security d'apache lève les règles d'alertes suivantes :
- 960015 : Request Missing an Accept Header
- 990011 : Request Indicates an automated program explored the site

Déjà fixé #3 mais apparemment retiré ensuite :)
