### PR TITLE
Fix deprecated usage

### DIFF
--- a/src/Openl10n/Sdk/EntryPoint/ResourceEntryPoint.php
+++ b/src/Openl10n/Sdk/EntryPoint/ResourceEntryPoint.php
@@ -88,7 +88,7 @@ class ResourceEntryPoint extends AbstractEntryPoint
     public function import(Resource $resource, $filepath, $locale, array $options = array())
     {
         $this->getClient()->post('resources/'.$resource->getId().'/import', [
-            'body' => [
+            'form_params' => [
                 'locale' => $locale,
                 'file' => fopen($filepath, 'r'),
                 'options' => $options,


### PR DESCRIPTION
Guzzle do not support files included as array in `body`, should now be passed using `form_params`