### PR TITLE
Implemented several methods in translation entry point

### DIFF
--- a/src/Openl10n/Sdk/EntryPoint/TranslationEntryPoint.php
+++ b/src/Openl10n/Sdk/EntryPoint/TranslationEntryPoint.php
@@ -2,6 +2,7 @@
 
 namespace Openl10n\Sdk\EntryPoint;
 
+use Openl10n\Sdk\Model\Project;
 use Openl10n\Sdk\Model\Translation;
 
 class TranslationEntryPoint extends AbstractEntryPoint
@@ -14,6 +15,39 @@ class TranslationEntryPoint extends AbstractEntryPoint
     public function findBy()
     {
         throw new \BadMethodCallException('Not implemented yet!');
+    }
+
+    /**
+     * Finds a Translation by its identifier
+     *
+     * @param Project $project
+     * @param string  $identifier
+     *
+     * @return Translation
+     */
+    public function findOneByIdentifier(Project $project, $identifier)
+    {
+        $results = json_decode(
+            $this->getClient()->get(
+                'translations',
+                [
+                    'query' => [
+                        'project'    => $project->getSlug(),
+                        'identifier' => $identifier
+                    ]
+                ]
+            )->getBody(),
+            true
+        );
+
+        if (count($results) === 1) {
+            $translation = new Translation($results[0]['identifier'], $results[0]['resource_id']);
+            $translation->setId($results[0]['id']);
+
+            return $translation;
+        }
+
+        return null;
     }
 
     public function get($id)
@@ -45,6 +79,6 @@ class TranslationEntryPoint extends AbstractEntryPoint
 
     public function delete(Translation $translation)
     {
-        throw new \BadMethodCallException('Not implemented yet!');
+        $this->getClient()->delete('translations/' . $translation->getId());
     }
 }


### PR DESCRIPTION
Hi Matthieu,

As I said here (https://github.com/openl10n/openl10n/pull/103), we needed to have API methods to remove translations. 

To do that, I added in the SDK two methods in the Translation entry point. The first one grabs a translation by its identifier, the second one calls the "delete" method, with a translation.

To merge after the openl10n's one, of course, if you accept it :)
